### PR TITLE
Change encoding of keywords.txt from UTF-8 BOM to UTF-8

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-﻿SirHenry	KEYWORD1
+SirHenry	KEYWORD1
 moveForeward	KEYWORD2
 moveBackward	KEYWORD2
 turnLeft	KEYWORD2


### PR DESCRIPTION
The BOM corrupted the first line of the file, causing the `SirHenry` keyword to not be recognized by the Arduino IDE.